### PR TITLE
Rename init method for abstract auth class

### DIFF
--- a/pal/authentication/auth_strategy.py
+++ b/pal/authentication/auth_strategy.py
@@ -9,7 +9,7 @@ class AbstractAuthenticationStrategy(ABC):
     Abstract base class for different authentication strategies.
     Authentication strategies are for getting s3 auth tokens/names.
     """
-    def __init(self):
+    def __init__(self):
         "Initialization method"
         super(AbstractAuthenticationStrategy, self).__init__()
 


### PR DESCRIPTION
Shouldn't the init method be `__init__(self)` instead of `__init(self)`?